### PR TITLE
fix version of ManCo to 2.0 as it should

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>tv.mineinthebox.manco</groupId>
 	<artifactId>ManCo</artifactId>
-	<version>3.0</version>
+	<version>2.0</version>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<resources>


### PR DESCRIPTION
Since the wiki pages say 2.0 we stay on 2.0

tl;tr

ManCo had two repositorities this one was the old version 1.x.
the new repository was ManCo2 which we then merged into the 1.x repository,
so we keep this as version 2.0 rather than 3.0 since it sounds better.
